### PR TITLE
ZIndex and Space included in showcases; other fixes

### DIFF
--- a/box/index.js
+++ b/box/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/box/src/Box.tsx
+++ b/box/src/Box.tsx
@@ -1,16 +1,15 @@
 import React, { CSSProperties, ReactNode } from 'react';
 
 const styles = {
-  checkered: { 
+  checkered: {
     opacity: 1,
     backgroundColor: '#000000',
-    backgroundImage:
-      `linear-gradient(45deg, #999 25%, transparent 25%),
+    backgroundImage: `linear-gradient(45deg, #999 25%, transparent 25%),
       linear-gradient(45deg, transparent 75%, #999 75%),
       linear-gradient(45deg, transparent 75%, #999  75%),
-      linear-gradient(45deg, #999 25%, #fff 25%)`,    
-    backgroundSize: `1rem 1rem`,       
-    backgroundPosition: `0 0, 0 0, -0.5rem -0.5rem, 0.5rem 0.5rem`, 
+      linear-gradient(45deg, #999 25%, #fff 25%)`,
+    backgroundSize: `1rem 1rem`,
+    backgroundPosition: `0 0, 0 0, -0.5rem -0.5rem, 0.5rem 0.5rem`,
     position: 'absolute',
     top: 0,
     zIndex: -1,
@@ -19,32 +18,37 @@ const styles = {
   wrapper: {
     position: 'relative',
   },
-  fullWidth: {
-    width: '100%',
-  },
   content: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-  }
+  },
 };
 
 interface BoxProps {
   checkeredBackground?: boolean;
-  fullWidth?: boolean,
   className?: string;
   style?: Record<string, any>;
   children: ReactNode | ReactNode[];
-};
+}
 
-export const Box = ({ checkeredBackground = true, className, style = {}, children }: BoxProps) => (
+export const Box = ({
+  checkeredBackground = true,
+  className,
+  style = {},
+  children,
+}: BoxProps) => (
   <div style={styles.wrapper as CSSProperties}>
-    {checkeredBackground &&
-    <div className={className} style={
-      { ...style, ...styles.checkered } as CSSProperties
-      } />
-    }
-    <div className={className} style={{ ...styles.content, ...style } as CSSProperties}>
+    {checkeredBackground && (
+      <div
+        className={className}
+        style={{ ...style, ...styles.checkered } as CSSProperties}
+      />
+    )}
+    <div
+      className={className}
+      style={{ ...styles.content, ...style } as CSSProperties}
+    >
       {children}
     </div>
   </div>

--- a/caption/index.js
+++ b/caption/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/playground/doc/playground.mdx
+++ b/playground/doc/playground.mdx
@@ -3,7 +3,8 @@ import { mdx, MDXCreateElement } from '@mdx-js/react';
 import { Props, Description } from '~/props/dist/index';
 import { Playground } from '../dist';
 import { Button } from '../test/index';
-
+import { Layout } from '~/mdx-layout';
+export default Layout;
 
 # Playground Component
 
@@ -16,19 +17,21 @@ import { Playground } from '@divriots/dockit-react';
 import { Button } from './Button';
 
 <Playground scope={{ Button }} code={`
-  <Button>Button</Button> 
-  <Button primary>Primary</Button> 
-  <Button danger>Danger</Button> 
+  <Button>Button</Button>
+  <Button primary>Primary</Button>
+  <Button danger>Danger</Button>
   `} />
 ```
 
-<Playground scope={{ Button }} code={`
+<Playground
+  scope={{ Button }}
+  code={`
 <Button>Button</Button> 
 <Button primary>Primary</Button> 
 <Button danger>Danger</Button> 
-`} />
-
+`}
+/>
 
 ## Props
-<Props of={Playground} />
 
+<Props of={Playground} />

--- a/playground/index.js
+++ b/playground/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/props/doc/props.mdx
+++ b/props/doc/props.mdx
@@ -1,6 +1,8 @@
-import { mdx } from "@mdx-js/react";
+import { mdx } from '@mdx-js/react';
 import { Props, Description } from '../dist';
 import { Button } from '../test';
+import { Layout } from '~/mdx-layout';
+export default Layout;
 
 # Props Component
 
@@ -9,6 +11,7 @@ import { Button } from '../test';
 It requires the [babel react docgen plugin](https://www.npmjs.com/package/babel-plugin-react-docgen).
 
 ### Example: Props of `Button` component
+
 <Props of={Button} />
 
 ## Usage
@@ -21,5 +24,5 @@ import { Props } from '@divriots/dockit-react';
 ```
 
 ## Props
-<Props of={Props} />
 
+<Props of={Props} />

--- a/props/index.js
+++ b/props/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/showcases/doc/showcases.mdx
+++ b/showcases/doc/showcases.mdx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { mdx, MDXCreateElement } from '@mdx-js/react';
+import { Props, Description } from '~/props/dist/index';
+import { Showcases } from '../dist';
+import { Layout } from '~/mdx-layout';
+import '../dist/showcases-stories.css';
+
+export default Layout;
+
+# Showcases Component
+
+<Description of={Showcases} />
+
+## Usage
+
+```
+import { Showcases } from '@divriots/dockit-react';
+
+const classes = [
+    'opacity-0',
+    'opacity-10',
+    'opacity-20',
+    'opacity-30',
+    'opacity-40',
+    'opacity-50',
+    'opacity-60',
+    'opacity-70',
+    'opacity-80',
+    'opacity-90',
+    'opacity-100',
+  ];
+
+<Showcases
+  showcaseClasses={classes}
+  showcaseComponent="box"
+  componentProps={{
+    className: "box",
+    checkeredBackground: true
+  }}
+/>
+```
+
+<Showcases
+  showcaseClasses={[
+    'opacity-0',
+    'opacity-10',
+    'opacity-20',
+    'opacity-30',
+    'opacity-40',
+    'opacity-50',
+    'opacity-60',
+    'opacity-70',
+    'opacity-80',
+    'opacity-90',
+    'opacity-100',
+  ]}
+  showcaseComponent="box"
+  componentProps={{
+    className: 'box',
+    checkeredBackground: true,
+  }}
+/>
+
+## Props
+
+<Props of={Showcases} />

--- a/showcases/index.js
+++ b/showcases/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/showcases/src/Showcases.tsx
+++ b/showcases/src/Showcases.tsx
@@ -26,15 +26,27 @@ const styles = {
     flexDirection: 'row-reverse',
     justifyContent: 'flex-end',
   },
-}
+};
 
-type Gap = { horizontal?: number, vertical?: number };
+type Gap = { horizontal?: number; vertical?: number };
 type ComponentType = 'box' | 'text' | undefined;
 
 type ShowcasesProps = {
+  /**
+  Array of css classes to be showcased
+   */
   showcaseClasses: string[];
+  /**
+  The component type to be used to showcase.
+   */
   showcaseComponent?: ComponentType;
+  /**
+  The showcase component props.
+   */
   componentProps?: Record<string, any>;
+  /**
+  The gap between showcase components.
+   */
   gap?: Gap;
 };
 
@@ -46,7 +58,14 @@ type CaptionedComponentProps = {
   captionWidth: string;
 };
 
-const CaptionedComponent = ({ caption, className, gap, type, captionWidth, ...otherProps}: CaptionedComponentProps) => {
+const CaptionedComponent = ({
+  caption,
+  className,
+  gap,
+  type,
+  captionWidth,
+  ...otherProps
+}: CaptionedComponentProps) => {
   const [hovered, setHovered] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -59,44 +78,58 @@ const CaptionedComponent = ({ caption, className, gap, type, captionWidth, ...ot
   const marginV = gap?.vertical ? `${gap.vertical / 2}px` : `0px`;
   const marginH = gap?.horizontal ? `${gap.horizontal / 2}px` : `0px`;
 
-
   const isText = type === 'text';
   const Component = isText ? Text : Box;
-  const componentContainer = isText ? styles.rowComponentContainer : styles.columnComponentContainer;
-
+  const componentContainer = isText
+    ? styles.rowComponentContainer
+    : styles.columnComponentContainer;
 
   return (
-    <div style={{
-      ...componentContainer,
-      margin: `${marginV} ${marginH}`
-     } as CSSProperties}>
+    <div
+      style={
+        {
+          ...componentContainer,
+          margin: `${marginV} ${marginH}`,
+        } as CSSProperties
+      }
+    >
       <Component className={className} {...otherProps} />
       <Caption text={caption} width={captionWidth} />
     </div>
-  )
-}
+  );
+};
 
-export const Showcases = ({ showcaseClasses = [], showcaseComponent = 'box', componentProps = {}, gap = { horizontal: 20, vertical: 10 } }: ShowcasesProps ) => {
-  const { className, ...otherProps} = componentProps;
+export const Showcases = ({
+  showcaseClasses = [],
+  showcaseComponent = 'box',
+  componentProps = {},
+  gap = { horizontal: 20, vertical: 10 },
+}: ShowcasesProps) => {
+  const { className, ...otherProps } = componentProps;
   const fixedClassName = className || '';
 
-  const container = showcaseComponent === 'box' ?  styles.rowContainer : styles.columnContainer;
+  const container =
+    showcaseComponent === 'box' ? styles.rowContainer : styles.columnContainer;
 
-  const longestClassName = showcaseClasses.reduce((max, e) => Math.max(e.length, max), 0);
+  const longestClassName = showcaseClasses.reduce(
+    (max, e) => Math.max(e.length, max),
+    0
+  );
   const captionWidth = `${longestClassName / 2}rem`;
 
   return (
     <div style={container as CSSProperties}>
       {showcaseClasses.map((className: string) => (
         <CaptionedComponent
-            key={className}
-            gap={gap}
-            captionWidth={captionWidth}
-            caption={className}
-            className={`${fixedClassName} ${className}`}
-            type={showcaseComponent}
-            {...otherProps} />
+          key={className}
+          gap={gap}
+          captionWidth={captionWidth}
+          caption={className}
+          className={`${fixedClassName} ${className}`}
+          type={showcaseComponent}
+          {...otherProps}
+        />
       ))}
     </div>
   );
-}
+};

--- a/showcases/src/index.stories.tsx
+++ b/showcases/src/index.stories.tsx
@@ -3,7 +3,6 @@ import { Showcases } from './index';
 import './showcases-stories.css';
 
 export const opacity = () => {
-
   const classes = [
     'opacity-0',
     'opacity-10',
@@ -23,24 +22,15 @@ export const opacity = () => {
       showcaseClasses={classes}
       showcaseComponent="box"
       componentProps={{
-        className: "box",
-        checkeredBackground: true
+        className: 'box',
+        checkeredBackground: true,
       }}
     />
   );
 };
 
 export const fontSize = () => {
-
-  const classes = [
-    'xs',
-    'sm',
-    'base',
-    'lg',
-    'xl',
-    'xxl',
-    'xxxl',
-  ];
+  const classes = ['xs', 'sm', 'base', 'lg', 'xl', 'xxl', 'xxxl'];
 
   return (
     <Showcases

--- a/space/doc/space.mdx
+++ b/space/doc/space.mdx
@@ -1,5 +1,7 @@
-import { mdx } from "@mdx-js/react";
+import { mdx } from '@mdx-js/react';
 import { Space } from '../dist';
+import { Layout } from '~/mdx-layout';
+export default Layout;
 
 # Spacing
 
@@ -8,5 +10,3 @@ import { Space } from '../dist';
 <Space scale={[0, '.25rem', '.5rem', '1rem', '2rem', '4rem', '8rem']} />
 
 <Space scale={{ small: 4, medium: 8, large: 16 }} />
-
-

--- a/space/index.js
+++ b/space/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/system-ui-showcases/doc/system-ui-showcases.mdx
+++ b/system-ui-showcases/doc/system-ui-showcases.mdx
@@ -2,6 +2,8 @@ import { mdx } from '@mdx-js/react';
 import { Props, Description } from '~/props/dist/index';
 import { SystemUIShowcases } from '../dist';
 import { theme } from '../dist/primer-theme';
+import { Layout } from '~/mdx-layout';
+export default Layout;
 
 # SystemUIShowcases Component
 

--- a/system-ui-showcases/index.js
+++ b/system-ui-showcases/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/system-ui-showcases/src/SystemUIShowcases.tsx
+++ b/system-ui-showcases/src/SystemUIShowcases.tsx
@@ -139,6 +139,7 @@ const ShowcaseComponent = ({
 
 const keyDetails = {
   bg: { themeProp: 'colors', componentType: 'box' },
+  backgroundColor: { themeProp: 'colors', componentType: 'box' },
   boxShadow: { themeProp: 'shadows', componentType: 'box' },
   width: { themeProp: 'sizes', componentType: 'box' },
   height: { themeProp: 'sizes', componentType: 'box' },
@@ -170,6 +171,9 @@ const keyDetails = {
 /**
   With the `SystemUIShowcases` component you can render all variations of a property from
   System UI specification abiding theme (https://system-ui.com/theme/).
+  Supported keys: bg, backgroundColor, boxShadow, width, height, borderRadius, borderWidth,
+  borderStyle, borderColor, border, borderTop, borderBottom, borderLeft, borderRight, fontSize,
+  fontFamily, fontWeight, lineHeight, letterSpacing, color.
 */
 export const SystemUIShowcases = ({
   theme,

--- a/system-ui-showcases/src/SystemUIShowcases.tsx
+++ b/system-ui-showcases/src/SystemUIShowcases.tsx
@@ -11,6 +11,8 @@ import {
 import { Caption } from '~/caption';
 import { shortText, longText } from '~/text';
 import { getVariations } from './theme-helper';
+import { ZIndexShowcases } from './ZIndexShowcases';
+import { Space } from '~/space';
 
 interface SystemUIShowcasesProps {
   /**
@@ -36,23 +38,46 @@ const Box = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  ${shadow}
-  ${border}
-  ${space}
-  ${layout}
-  ${color}
+  position: relative;
+  ${shadow};
+  ${border};
+  ${space};
+  ${layout};
+  ${color};
+`;
+
+const CheckeredBackground = styled.div`
+  ${shadow};
+  ${border};
+  ${space};
+  ${layout};
+  ${color};
+  opacity: 1;
+  background-color: #000000;
+  background-image: linear-gradient(45deg, #999 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #999 75%),
+      linear-gradient(45deg, transparent 75%, #999 75%),
+        linear-gradient(45deg, #999 25%, #fff 25%);
+  background-size: 1rem 1rem;
+  background-position: 0 0, 0 0, -0.5rem -0.5rem, 0.5rem 0.5rem;
+  position: absolute;
+  top: 0;
+  z-index: -1;
+  boxshadow: none;
+  width: 100%;
+  height: 100%;
 `;
 
 const TextContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  ${shadow}
-  ${border}
-  ${space}
-  ${layout}
-  ${color}
-  ${typography}
+  ${shadow};
+  ${border};
+  ${space};
+  ${layout};
+  ${color};
+  ${typography};
 `;
 
 const Text = ({ useLongText = false, ...rest }) => (
@@ -92,20 +117,25 @@ const ShowcaseComponent = ({
   minWidth,
   type,
   useLongText,
-}: ShowcaseComponentProps) => (
-  <ComponentContainer
-    gap={gap}
-    minWidth={minWidth}
-    usedForText={type === 'text'}
-  >
-    {type === 'text' ? (
-      <Text {...componentProps} useLongText={useLongText} />
-    ) : (
-      <Box {...componentProps} />
-    )}
-    <Caption text={caption} width={minWidth} />
-  </ComponentContainer>
-);
+}: ShowcaseComponentProps) => {
+  const { checkeredBackground, ...props } = componentProps;
+  return (
+    <ComponentContainer
+      gap={gap}
+      minWidth={minWidth}
+      usedForText={type === 'text'}
+    >
+      {type === 'text' ? (
+        <Text {...props} useLongText={useLongText} />
+      ) : (
+        <Box {...props}>
+          {checkeredBackground && <CheckeredBackground {...props} />}
+        </Box>
+      )}
+      <Caption text={caption} width={minWidth} />
+    </ComponentContainer>
+  );
+};
 
 const keyDetails = {
   bg: { themeProp: 'colors', componentType: 'box' },
@@ -116,6 +146,11 @@ const keyDetails = {
   borderWidth: { themeProp: 'borderWidths', componentType: 'box' },
   borderStyle: { themeProp: 'borderStyles', componentType: 'box' },
   borderColor: { themeProp: 'colors', componentType: 'box' },
+  border: { themeProp: 'borders', componentType: 'box' },
+  borderTop: { themeProp: 'borders', componentType: 'box' },
+  borderBottom: { themeProp: 'borders', componentType: 'box' },
+  borderLeft: { themeProp: 'borders', componentType: 'box' },
+  borderRight: { themeProp: 'borders', componentType: 'box' },
   fontSize: { themeProp: 'fontSizes', componentType: 'text' },
   fontFamily: { themeProp: 'fonts', componentType: 'text' },
   fontWeight: { themeProp: 'fontWeights', componentType: 'text' },
@@ -142,6 +177,8 @@ export const SystemUIShowcases = ({
   componentProps = {},
   gap = { horizontal: '2rem', vertical: '2rem' },
 }: SystemUIShowcasesProps) => {
+  if (showcaseKey === 'zIndex') return <ZIndexShowcases theme={theme} />;
+  if (showcaseKey === 'space') return <Space scale={theme.space} />;
   if (!keyDetails[showcaseKey])
     return <Error>{`"${showcaseKey}" is not yet supported.`}</Error>;
 
@@ -157,7 +194,7 @@ export const SystemUIShowcases = ({
     (max, e) => Math.max(`${showcaseKey}=${e}`.length, max),
     0
   );
-  const componentWidth = `${longestPropertyName / 2.4}rem`;
+  const componentWidth = `${longestPropertyName / 2.2}rem`;
 
   return (
     <ThemeProvider theme={theme}>

--- a/system-ui-showcases/src/ZIndexShowcases.tsx
+++ b/system-ui-showcases/src/ZIndexShowcases.tsx
@@ -31,21 +31,23 @@ export const ZIndexShowcases = ({ theme }: { theme: Record<string, any> }) => {
           display: 'flex',
           flexDirection: 'row',
           justifyContent: 'center',
+          marginTop: '3rem',
         }}
       >
         {variations.map((v, i) => (
           <Box
-            bg="#444"
-            ml="-2rem"
-            mt={`${i}rem`}
-            width="12rem"
+            bg="#6365f1"
+            ml="-6rem"
+            mt={`${4 * i}rem`}
             height="6rem"
+            px="1rem"
             borderRadius=".5rem"
             display="flex"
             justifyContent="center"
             alignItems="center"
-            boxShadow="0 12px 48px rgba(149, 157, 165, 0.3)"
+            boxShadow="0 12px 48px rgba(149, 157, 165, 0.6)"
             zIndex={v}
+            border="1px solid #fff"
           >
             <div style={{ color: '#fff' }}>{`zIndex="${v}"`}</div>
           </Box>

--- a/system-ui-showcases/src/index.stories.tsx
+++ b/system-ui-showcases/src/index.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { SystemUIShowcases, ZIndexShowcases } from './index';
-import { Space } from '~/space';
 import { theme } from './primer-theme';
 
-export const space = () => <Space scale={theme.space} />;
+export const space = () => (
+  <SystemUIShowcases theme={theme} showcaseKey="space" />
+);
 
 export const width = () => (
   <SystemUIShowcases
@@ -38,14 +39,15 @@ export const bg = () => (
       height: '8rem',
       boxShadow: 'large',
       borderRadius: 4,
+      checkeredBackground: true,
     }}
   />
 );
 
-export const boxShadow = () => (
+export const shadows = () => (
   <SystemUIShowcases
     theme={theme}
-    showcaseKey="boxShadow"
+    showcaseKey="shadows"
     componentProps={{
       width: '8rem',
       height: '8rem',
@@ -113,6 +115,67 @@ export const borderColor = () => (
   />
 );
 
+export const border = () => (
+  <SystemUIShowcases
+    theme={theme}
+    showcaseKey="border"
+    componentProps={{
+      width: '8rem',
+      height: '8rem',
+      boxShadow: 'large',
+      borderRadius: '1',
+    }}
+  />
+);
+
+export const borderTop = () => (
+  <SystemUIShowcases
+    theme={theme}
+    showcaseKey="borderTop"
+    componentProps={{
+      width: '8rem',
+      height: '8rem',
+      boxShadow: 'large',
+    }}
+  />
+);
+
+export const borderBottom = () => (
+  <SystemUIShowcases
+    theme={theme}
+    showcaseKey="borderBottom"
+    componentProps={{
+      width: '8rem',
+      height: '8rem',
+      boxShadow: 'large',
+    }}
+  />
+);
+
+export const borderLeft = () => (
+  <SystemUIShowcases
+    theme={theme}
+    showcaseKey="borderLeft"
+    componentProps={{
+      width: '8rem',
+      height: '8rem',
+      boxShadow: 'large',
+    }}
+  />
+);
+
+export const borderRight = () => (
+  <SystemUIShowcases
+    theme={theme}
+    showcaseKey="borderRight"
+    componentProps={{
+      width: '8rem',
+      height: '8rem',
+      boxShadow: 'large',
+    }}
+  />
+);
+
 export const fontSize = () => (
   <SystemUIShowcases theme={theme} showcaseKey="fontSize" />
 );
@@ -137,4 +200,6 @@ export const color = () => (
   <SystemUIShowcases theme={theme} showcaseKey="color" />
 );
 
-export const zIndex = () => <ZIndexShowcases theme={theme} />;
+export const zIndex = () => (
+  <SystemUIShowcases theme={theme} showcaseKey="zIndex" />
+);

--- a/system-ui-showcases/src/primer-theme.ts
+++ b/system-ui-showcases/src/primer-theme.ts
@@ -1,11 +1,16 @@
 export const theme = {
   borderWidths: [0, '1px'],
+  borders: {
+    thinBlack: '1px solid #000',
+    thickBlack: '4px solid #000',
+  },
   borderStyles: ['solid', 'dotted', 'dashed', 'groove'],
   breakpoints: ['544px', '768px', '1012px', '1280px'],
   colors: {
     bodytext: '#24292e',
     black: '#1b1f23',
     white: '#fff',
+    gray50: '#24292e88',
     gray: [
       '#fafbfc',
       '#f6f8fa',

--- a/tailwind-showcases/doc/tailwind-showcases.mdx
+++ b/tailwind-showcases/doc/tailwind-showcases.mdx
@@ -1,6 +1,8 @@
 import { mdx } from '@mdx-js/react';
 import { Props, Description } from '~/props/dist/index';
 import { TailwindShowcases } from '../dist';
+import { Layout } from '~/mdx-layout';
+export default Layout;
 
 # TailwindShowcases Component
 

--- a/tailwind-showcases/index.js
+++ b/tailwind-showcases/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/tailwind-showcases/src/TailwindShowcases.tsx
+++ b/tailwind-showcases/src/TailwindShowcases.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Showcases } from '~/showcases';
 import { extractClassSuffixes } from './theme-helpers';
 import resolveConfig from 'tailwindcss/resolveConfig';
+import { ZIndexShowcases } from './ZIndexShowcases';
+import { Space } from '~/space';
 
 const styles = {
   error: {
@@ -104,6 +106,9 @@ export const TailwindShowcases = ({
   gap,
 }: TailwindShowcasesProps) => {
   const { theme } = resolveConfig({ theme: partialTheme });
+  if (showcaseKey === 'zIndex') return <ZIndexShowcases theme={theme} />;
+
+  if (showcaseKey === 'space') return <Space scale={theme.spacing} />;
 
   const classSuffixes = getClassSuffixes(theme);
   const classNames = getClassNames(classSuffixes);

--- a/tailwind-showcases/src/ZIndexShowcases.tsx
+++ b/tailwind-showcases/src/ZIndexShowcases.tsx
@@ -2,18 +2,34 @@ import React from 'react';
 import { extractClassSuffixes } from './theme-helpers';
 
 export const ZIndexShowcases = ({ theme }: { theme: Record<string, any> }) => {
-  const classes = extractClassSuffixes('zIndex', theme).map(s => `z${s}`);
+  const classes = extractClassSuffixes('zIndex', theme).map((s) => `z${s}`);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'row-reverse', justifyContent: 'center' }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'center',
+      }}
+    >
       {classes.map((cls, i) => (
         <div
-          className={`${cls} h-32 w-32 -ml-10 rounded-md bg-indigo-500 shadow-2xl`}
-          style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: i*10 }}
+          className={`${cls} rounded-md bg-indigo-500 shadow-2xl`}
+          style={{
+            height: '6rem',
+            minWidth: '8rem',
+            marginLeft: '-6rem',
+            padding: '2rem',
+            marginTop: `${4 * i}rem`,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            border: '1px solid #fff',
+          }}
         >
           <div className="text-white">{cls}</div>
         </div>
       ))}
     </div>
-  )
+  );
 };

--- a/tailwind-showcases/src/index.stories.tsx
+++ b/tailwind-showcases/src/index.stories.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import { TailwindShowcases, ZIndexShowcases } from './index';
 import 'twind/shim';
 import twTheme from 'tailwindcss/defaultTheme.js';
-import { Space } from '~/space';
 
 export const bg_color = () => (
   <TailwindShowcases
     theme={twTheme}
     showcaseKey="backgroundColor"
     componentProps={{
-      className: "shadow-xl h-32 w-32",
+      className: 'shadow-xl h-32 w-32',
       checkeredBackground: true,
     }}
   />
@@ -20,7 +19,7 @@ export const opacity = () => (
     theme={twTheme}
     showcaseKey="opacity"
     componentProps={{
-      className: "shadow-xl h-32 w-32 bg-blue-700",
+      className: 'shadow-xl h-32 w-32 bg-blue-700',
     }}
   />
 );
@@ -30,7 +29,7 @@ export const shadow = () => (
     theme={twTheme}
     showcaseKey="shadow"
     componentProps={{
-      className: "h-32 w-32 bg-white",
+      className: 'h-32 w-32 bg-white',
     }}
   />
 );
@@ -40,7 +39,7 @@ export const border_radius = () => (
     theme={twTheme}
     showcaseKey="borderRadius"
     componentProps={{
-      className: "shadow-2xl h-32 w-32 bg-blue-400",
+      className: 'shadow-2xl h-32 w-32 bg-blue-400',
     }}
   />
 );
@@ -50,7 +49,7 @@ export const border_width = () => (
     theme={twTheme}
     showcaseKey="borderWidth"
     componentProps={{
-      className: "h-32 w-32 bg-gray-50",
+      className: 'h-32 w-32 bg-gray-50',
     }}
   />
 );
@@ -60,7 +59,7 @@ export const border_color = () => (
     theme={twTheme}
     showcaseKey="borderColor"
     componentProps={{
-      className: "h-32 w-32 bg-gray-50 border-4 rounded",
+      className: 'h-32 w-32 bg-gray-50 border-4 rounded',
     }}
   />
 );
@@ -68,7 +67,6 @@ export const border_color = () => (
 export const font_family = () => (
   <TailwindShowcases theme={twTheme} showcaseKey="fontFamily" />
 );
-
 
 export const font_size = () => (
   <TailwindShowcases theme={twTheme} showcaseKey="fontSize" />
@@ -94,8 +92,10 @@ export const text_color = () => (
   <TailwindShowcases theme={twTheme} showcaseKey="textColor" />
 );
 
-export const z_index = () => <ZIndexShowcases theme={twTheme} />;
+export const z_index = () => (
+  <TailwindShowcases theme={twTheme} showcaseKey="zIndex" />
+);
 
-export const spacing = () => (
-  <Space scale={twTheme.spacing} />
+export const space = () => (
+  <TailwindShowcases theme={twTheme} showcaseKey="space" />
 );

--- a/tailwind-showcases/src/index.ts
+++ b/tailwind-showcases/src/index.ts
@@ -1,2 +1,1 @@
 export { TailwindShowcases } from './TailwindShowcases';
-export { ZIndexShowcases } from './ZIndexShowcases';

--- a/text/index.js
+++ b/text/index.js
@@ -1,0 +1,1 @@
+export * from './src/index';


### PR DESCRIPTION
- added `border`, `borderTop`, `borderRight`, `borderBottom`, `borderLeft` as supported keys for SystemUIShowcases component
- fixed zIndex layout and look and feel for both System UI and Tailwind showcases, and they are now included as keys in the showcasing component
- added index.js for proper importing
- fixed mdx docs layout