### PR TITLE
increased label width and shrink nav header width

### DIFF
--- a/mdx-layout-core/src/NavBar.scss
+++ b/mdx-layout-core/src/NavBar.scss
@@ -1,6 +1,6 @@
 nav {
   header {
-    width: 98%;
+    width: calc(100% - 1rem);
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/mdx-layout-core/src/NavBar.scss
+++ b/mdx-layout-core/src/NavBar.scss
@@ -1,6 +1,6 @@
 nav {
   header {
-    width: 100%;
+    width: 98%;
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/systemui-showcases/src/SystemUIShowcases.tsx
+++ b/systemui-showcases/src/SystemUIShowcases.tsx
@@ -209,7 +209,7 @@ export const SystemUIShowcases = ({
     (max, e) => Math.max(`${showcaseKey}=${e}`.length, max),
     0
   );
-  const componentWidth = `${longestPropertyName / 2.2}rem`;
+  const componentWidth = `${longestPropertyName / 1.8}rem`;
 
   return (
     <ThemeProvider theme={theme}>


### PR DESCRIPTION
- shrink header width so that the menu icon does not overlap colorscheme switch
- label width increased for system ui showcases so that it doesn't wrap