### PR TITLE
changed Playground editor theme to make it resemble <code> theme

### DIFF
--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
-import dracula from 'prism-react-renderer/themes/dracula';
-import toJSXString from 'react-element-to-jsx-string';
+import oceanicNext from 'prism-react-renderer/themes/oceanicNext';
 
 const styles = {
   preview: {
@@ -40,7 +39,7 @@ export const Playground = ({ code, scope }: PlaygroundProps) => (
   <LiveProvider
     code={code.trim()}
     scope={scope}
-    theme={dracula}
+    theme={oceanicNext}
     transformCode={(code) => `<>${code}</>`}
   >
     <div>


### PR DESCRIPTION
For some reason, the exact same prism theme is not available for prism-react-renderer, but this one is closer than what we had
![image](https://user-images.githubusercontent.com/7051248/111598092-82f8e480-87d7-11eb-9b98-6687c6207f20.png)
