### PR TITLE
Provide extra classes for blocks inside the playground

### DIFF
--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -53,6 +53,11 @@ type PlaygroundProps = {
    * Allows to render multiple components.
    */
   noInline?: boolean;
+
+  /**
+   * ClassName(s) to pass to inner blocks
+   */
+  innerClassName?: string;
 };
 
 /**
@@ -62,6 +67,7 @@ export const Playground = ({
   code,
   scope,
   noInline,
+  innerClassName,
   ...props
 }: PlaygroundProps) => {
   const commentsRegex = /([^http:|https:]\/\/.*)|(\/\*(.|\n)*?\*\/)/gm;
@@ -83,10 +89,16 @@ export const Playground = ({
       }}
     >
       <div {...props}>
-        <div style={styles.preview}>
+        <div
+          style={styles.preview}
+          className={`${innerClassName} live-preview`}
+        >
           <LivePreview />
         </div>
-        <div style={styles.editorContainer}>
+        <div
+          style={styles.editorContainer}
+          className={`${innerClassName} live-editor`}
+        >
           <LiveEditor style={styles.editor} />
         </div>
         <LiveError style={styles.error} />

--- a/playground/stories/index.stories.tsx
+++ b/playground/stories/index.stories.tsx
@@ -32,3 +32,16 @@ export const Button_doc_with_shadow_playground = () => (
     `}
   />
 );
+
+export const Button_doc_with_playground_and_inner_classes = () => (
+  <Playground
+    style={{ width: '400px', height: '300px' }}
+    styles={styles}
+    innerClassName="inner-demo"
+    code={`
+<button className="btn">Button</button>
+<button className="btn btn-primary">Primary</button>
+<button className="btn btn-danger">Danger</button>
+    `}
+  />
+);

--- a/playground/test/styles.css
+++ b/playground/test/styles.css
@@ -15,3 +15,15 @@
   background-color: rgb(203, 36, 49);
   color: rgb(255, 255, 255);
 }
+
+.inner-demo {
+  font-size: 0.75rem;
+}
+
+.inner-demo.live-preview {
+  border-radius: 0.375rem 0.375rem 0 0;
+}
+
+.inner-demo.live-editor {
+  border-radius: 0 0 0.375rem 0.375rem !important;
+}


### PR DESCRIPTION
Add the ability to provide extra classes to block in a playground, so we can use them to customise the appearance of the playground in documents directly:

```tsx
export const Button_doc_with_playground_and_inner_classes = () => (
  <Playground
    innerClassName="inner-demo"
    code={`
<button className="btn">Button</button>
    `}
  />
);
```