### PR TITLE
fix(box): make checkerboard visible with set opacity in multistories

### DIFF
--- a/box/src/Box.tsx
+++ b/box/src/Box.tsx
@@ -17,6 +17,7 @@ const styles = {
   },
   wrapper: {
     position: 'relative',
+    zIndex: 0,
   },
   content: {
     display: 'flex',


### PR DESCRIPTION
Fixes same issue which I previously found in dockit-core: https://github.com/divriots/dockit-core/pull/40

Btw, we can also look into fixing this on the multi-stories side too, but I feel like it's good to do this fix too, because then we can use it in more environments. E.g. the dockit-core fix was needed also for mdjs-layout which has a relative position of the container too, so in other words this fix makes it work in such environments, including the multi-stories view.

![image](https://user-images.githubusercontent.com/137844/151954217-68d77314-8238-4541-b701-6d171904903a.png)
